### PR TITLE
Add GlitchTip support

### DIFF
--- a/sentry-client.lisp
+++ b/sentry-client.lisp
@@ -178,9 +178,11 @@ move this to trivial-backtrace in the future"
                               sentry-client
                               :extras extras)
       (json:as-object-member ("exception")
-        (json:with-object ()
-          (encode-exception condition json:*json-output*
-                            sentry-client))))))
+        (json:with-array ()
+          (json:as-array-member ("values")
+            (json:with-object ()
+              (encode-exception condition json:*json-output*
+                                sentry-client))))))))
 
 (defmethod client-capture-exception ((sentry-client sentry-client) condition &rest args &key tags extras)
   (post-sentry-request (encode-exception-event condition sentry-client :extras extras) sentry-client))


### PR DESCRIPTION
GlitchTip does not recognize most of the JSON posted by `cl-sentry-client`. Exceptions are hidden from the UI and titles default to `<unknown>`. The [documentation](https://develop.sentry.dev/sdk/event-payloads/exception/) says:
> The `exception` attribute should be an object with the attribute `values` containing a list of one or more values that are objects in the format described below. Alternatively, the `exception` attribute may be a flat list of objects in the format below.

This change adds the `values`-attribute that, according to the documentation, should be present, and fixes the GlitchTip problem mentioned in the first sentence.