### PR TITLE
Remove unnecessary fmt package & remove sentry_sentry auth arg

### DIFF
--- a/sentry-client.asd
+++ b/sentry-client.asd
@@ -11,7 +11,6 @@
                :cl-json
                :cl-ppcre
                :uuid
-               :fmt
                :local-time
                :trivial-backtrace)
   :components ((:file "package")

--- a/sentry-client.lisp
+++ b/sentry-client.lisp
@@ -105,12 +105,12 @@ If no TIMESTAMP is provided, then current time is used."
 
 (defun encode-sentry-auth-header (sentry-client)
   "Encode Sentry authentication header."
-  (fmt:fmt nil "Sentry sentry_version=" 5 ","
-           "sentry_client=" "cl-sentry-client/"
-           (asdf:component-version (asdf:find-system :sentry-client)) ","
-           "sentry_timestamp=" (format-sentry-timestamp nil (local-time:now)) ","
-           "sentry_key=" (getf (dsn sentry-client) :public-key) ","
-           "sentry_secret=" (getf (dsn sentry-client) :secret-key)))
+  (format nil "Sentry ~:{~(~A~)=~A~:^,~}"
+          `((sentry_version 5)
+            (sentry_client ,(concatenate 'string "cl-sentry-client/"
+                                         (asdf:component-version (asdf:find-system :sentry-client))))
+            (sentry_timestamp ,(format-sentry-timestamp nil (local-time:now)))
+            (sentry_key ,(getf (dsn sentry-client) :public-key)))))
 
 (defun post-sentry-request (data &optional (sentry-client *sentry-client*))
   "Just send DATA to sentry api via HTTP."


### PR DESCRIPTION
Hello, nice to see some activity in this repository!

I'm back again with another PR. 

[Marshal](https://github.com/wlbr/cl-marshal) had the bright idea to `:nicknames` one of its packages `fmt`, which conflicts with the `fmt` package this library requires, so I replaced `fmt` with a `format`. Since the `fmt` library is only used once (to format that Auth header) and I think my suggested replacement is a bit more readable (maybe not the control-string tho :p), I removed the `:depends-on` as well in the asd-file.

Additionally, [Sentry SDK - Authentication](https://develop.sentry.dev/sdk/overview/#authentication) states `sentry_secret` to be effectively deprecated, so I removed it in the same commit from the Auth header since there's no `sentry_secret` referenced anywhere anymore. Also, the resulting value of `sentry_secret` would end up being `NIL`, which the docs whine about:

> The `sentry_secret` must only be included if a secret key portion was contained in the DSN.

Lastly, an unrelated matter: I noticed `sentry_version=5`, while the docs state the `sentry_version` to be 7. My search efforts could not determine whether it affects anything, so I'm just giving a heads-up. Maybe you know if its wanted or not.

Thanks