### PR TITLE
Delete declaim for debugging

### DIFF
--- a/stacktrace.lisp
+++ b/stacktrace.lisp
@@ -1,7 +1,5 @@
 (in-package :sentry-client)
 
-(declaim (optimize (speed 0) (safety 3) (debug 3)))
-
 (defun split-lines (string)
   (uiop:split-string string :separator '(#\newline)))
 


### PR DESCRIPTION
Declaim was left over from debugging the stack trace, so it was removed.